### PR TITLE
Add delay to linefeed write when completing game handshake.

### DIFF
--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -899,6 +899,7 @@ namespace GenieClient.Genie
                 case ConnectStates.ConnectedGameHandshake:
                     {
                         m_oConnectState = ConnectStates.ConnectedGame;
+                        Thread.Sleep(1000);
                         m_oSocket.Send(Constants.vbLf + Constants.vbLf);
                         break;
                     }


### PR DESCRIPTION
The linefeed write was to prompt the server to begin sending data. I think it was happening before the server was ready and so it would get hung on the initial connection. Adding a slight delay improves handshake completion reliability.