### PR TITLE
Add combat logging

### DIFF
--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -204,6 +204,7 @@ namespace GenieClient.Genie
         public enum WindowTarget
         {
             Unknown,
+            Combat,
             Main,
             Inv,
             Familiar,
@@ -1317,6 +1318,11 @@ namespace GenieClient.Genie
                             var switchExpr3 = GetAttributeData(oXmlNode, argstrAttributeName13);
                             switch (switchExpr3)
                             {
+                                case "combat":
+                                    {
+                                        m_oTargetWindow = WindowTarget.Combat;
+                                        break;
+                                    }
                                 case "main":
                                     {
                                         m_oTargetWindow = WindowTarget.Main;
@@ -2646,6 +2652,12 @@ namespace GenieClient.Genie
                         break;
                     }
 
+                case WindowTarget.Combat:
+                    {
+                        sTargetWindowString = "combat";
+                        break;
+                    }
+
                 case WindowTarget.Familiar:
                     {
                         sTargetWindowString = "familiar";
@@ -2803,7 +2815,7 @@ namespace GenieClient.Genie
                 }
             }
 
-            if (targetwindow == WindowTarget.Main | targetwindow == WindowTarget.Thoughts)
+            if (targetwindow == WindowTarget.Main | targetwindow == WindowTarget.Thoughts | targetwindow == WindowTarget.Combat)
             {
                 if (m_oGlobals.Config.bAutoLog == true)
                 {


### PR DESCRIPTION
Adds parsing of combat xml tags, sets proper window target, and writes combat messages to Log

Closes #6 

Pulled from character /Logs/ file:

![image](https://user-images.githubusercontent.com/2636762/147708496-18b88a7c-6dd1-413c-a649-5bb3cbb76713.png)
