### PR TITLE
Lich host change

### DIFF
--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -370,6 +370,7 @@ namespace GenieClient.Genie
                                             Connect(oArgs);
                                             break;
                                         }
+
                                     case "lc":
                                     case "lconnect":
                                         {
@@ -386,6 +387,7 @@ namespace GenieClient.Genie
                                             Connect(oArgs, true);
                                             break;
                                         }
+
                                     case "ls":
                                     case "lichsettings":
                                         {

--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows.Forms;
 using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
@@ -14,11 +15,11 @@ namespace GenieClient.Genie
     {
         public event EventReconnectEventHandler EventReconnect;
 
-        public delegate void EventReconnectEventHandler();
+        public delegate void EventReconnectEventHandler(bool isLich);
 
         public event EventConnectEventHandler EventConnect;
 
-        public delegate void EventConnectEventHandler(string sAccountName, string sPassword, string sCharacter, string sGame);
+        public delegate void EventConnectEventHandler(string sAccountName, string sPassword, string sCharacter, string sGame, bool isLich);
 
         public event EventDisconnectEventHandler EventDisconnect;
 
@@ -366,35 +367,39 @@ namespace GenieClient.Genie
 
                                     case "connect":
                                         {
-                                            if (oArgs.Count == 1)
-                                            {
-                                                // EchoText("Reconnect Command Received" & vbNewLine)
-                                                EventReconnect?.Invoke();
-                                            }
-                                            else if (oArgs.Count == 5)
-                                            {
-                                                // EchoText("Connect Command Received" & vbNewLine);
-                                                var arg1 = oGlobals.ParseGlobalVars(oArgs[1].ToString());
-                                                var arg2 = oGlobals.ParseGlobalVars(oArgs[2].ToString());
-                                                var arg3 = oGlobals.ParseGlobalVars(oArgs[3].ToString());
-                                                var arg4 = oGlobals.ParseGlobalVars(oArgs[4].ToString());
-
-                                                EventConnect?.Invoke(arg1, arg2, arg3, arg4);
-                                            }
-                                            else if (oArgs.Count == 2)
-                                            {
-                                                var arg1 = oGlobals.ParseGlobalVars(oArgs[1].ToString());
-                                                var argEmpty = "";
-                                                EventConnect?.Invoke(arg1, argEmpty, argEmpty, argEmpty);
-                                            }
-                                            else
-                                            {
-                                                EchoText("Invalid number of arguments in #connect command. Syntax: #connect account password character game" + Constants.vbNewLine);
-                                            }
-
+                                            Connect(oArgs);
                                             break;
                                         }
-
+                                    case "lc":
+                                    case "lconnect":
+                                        {
+                                            EchoText("Starting Lich Server\n");
+                                            string lichLaunch = $"/C {oGlobals.Config.RubyPath} {oGlobals.Config.LichPath} {oGlobals.Config.LichArguments}";
+                                            
+                                            Utility.ExecuteProcess(oGlobals.Config.CmdPath, lichLaunch, false);
+                                            int count = 0;
+                                            while (count < oGlobals.Config.LichStartPause) 
+                                            {
+                                                Thread.Sleep(1000);
+                                                count++;
+                                            }
+                                            Connect(oArgs, true);
+                                            break;
+                                        }
+                                    case "ls":
+                                    case "lichsettings":
+                                        {
+                                            EchoText($"\nLich Settings\n");
+                                            EchoText($"----------------------------------------------------\n");
+                                            EchoText($"Cmd Path:\t\t {oGlobals.Config.CmdPath}\n");
+                                            EchoText($"Ruby Path:\t\t {oGlobals.Config.RubyPath}\n");
+                                            EchoText($"Lich Path:\t\t {oGlobals.Config.LichPath}\n");
+                                            EchoText($"Lich Arguments:\t {oGlobals.Config.LichArguments}\n");
+                                            EchoText($"Lich Start Pause:\t {oGlobals.Config.LichStartPause}\n");
+                                            EchoText($"Lich Server:\t\t {oGlobals.Config.LichServer}\n");
+                                            EchoText($"Lich Port:\t\t {oGlobals.Config.LichPort}\n\n");
+                                            break;
+                                        }
                                     case "disconnect":
                                         {
                                             EventDisconnect?.Invoke();
@@ -2433,6 +2438,37 @@ namespace GenieClient.Genie
 
             /* TODO ERROR: Skipped IfDirectiveTrivia *//* TODO ERROR: Skipped DisabledTextTrivia *//* TODO ERROR: Skipped EndIfDirectiveTrivia */
             return sResult;
+        }
+
+
+        private void Connect(ArrayList args, bool isLich = false)
+        {
+            if (args.Count == 1)
+            {
+                // EchoText("Reconnect Command Received" & vbNewLine)
+                EventReconnect?.Invoke(isLich);
+            }
+            else if (args.Count == 5)
+            {
+                // EchoText("Connect Command Received" & vbNewLine);
+                var arg1 = oGlobals.ParseGlobalVars(args[1].ToString());
+                var arg2 = oGlobals.ParseGlobalVars(args[2].ToString());
+                var arg3 = oGlobals.ParseGlobalVars(args[3].ToString());
+                var arg4 = oGlobals.ParseGlobalVars(args[4].ToString());
+
+                EventConnect?.Invoke(arg1, arg2, arg3, arg4, isLich);
+            }
+            else if (args.Count == 2)
+            {
+                var arg1 = oGlobals.ParseGlobalVars(args[1].ToString());
+                var argEmpty = "";
+                EventConnect?.Invoke(arg1, argEmpty, argEmpty, argEmpty,isLich);
+            }
+            else
+            {
+                EchoText("Invalid number of arguments in #connect command. Syntax: #connect account password character game" + Constants.vbNewLine);
+            }
+
         }
 
         public string Eval(string sText)

--- a/Core/Connection.cs
+++ b/Core/Connection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -143,7 +144,8 @@ namespace GenieClient.Genie
 
                 m_sHostname = sHostname;
                 m_SocketClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                m_IPEndPoint = new IPEndPoint(Dns.GetHostEntry(sHostname).AddressList[0], iPort);
+                var hostEntryList = Dns.GetHostEntry(sHostname);
+                m_IPEndPoint = new IPEndPoint(hostEntryList.AddressList.Where(i => i.AddressFamily == AddressFamily.InterNetwork).FirstOrDefault(), iPort);
                 m_SocketClient.BeginConnect(m_IPEndPoint, new AsyncCallback(ConnectCallback), m_SocketClient);
             }
             catch (SocketException ex)

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -199,6 +199,7 @@ namespace GenieClient.Genie
         private ConnectStates m_oConnectState;
         private object m_oThreadLock = new object(); // Thread safety
         private bool m_bFamiliarLineParse = false;
+        public bool IsLich = false;
 
         /* TODO ERROR: Skipped RegionDirectiveTrivia */
         public enum WindowTarget
@@ -371,8 +372,9 @@ namespace GenieClient.Genie
             }
         }
 
-        public void Connect(string sGenieKey, string sAccountName, string sPassword, string sCharacter, string sGame)
+        public void Connect(string sGenieKey, string sAccountName, string sPassword, string sCharacter, string sGame, bool isLich = false)
         {
+            this.IsLich = isLich;
             m_sAccountName = sAccountName;
             m_sAccountPassword = sPassword;
             m_sAccountCharacter = sCharacter;
@@ -394,6 +396,8 @@ namespace GenieClient.Genie
                 m_oSocket.Disconnect();
             }
         }
+
+
 
         public void SendText(string sText, bool bUserInput = false, string sOrigin = "")
         {
@@ -766,9 +770,9 @@ namespace GenieClient.Genie
             {
                 oDocument.LoadXml("<data>" + sXML + "</data>");
             }
-            #pragma warning disable CS0168
+#pragma warning disable CS0168
             catch (XmlException ex)
-            #pragma warning restore CS0168
+#pragma warning restore CS0168
             {
                 /* TODO ERROR: Skipped IfDirectiveTrivia *//* TODO ERROR: Skipped DisabledTextTrivia *//* TODO ERROR: Skipped EndIfDirectiveTrivia */
                 return sReturn;
@@ -1084,17 +1088,19 @@ namespace GenieClient.Genie
                                     {
                                         if (strRow.IndexOf("GAMEHOST=") > -1)
                                         {
-                                            m_sConnectHost = strRow.Substring(9);
+                                            m_sConnectHost = IsLich ? m_oGlobals.Config.LichServer : strRow.Substring(9);
                                         }
                                         else if (strRow.IndexOf("GAMEPORT=") > -1)
                                         {
-                                            m_sConnectPort = int.Parse(strRow.Substring(9));
+                                            m_sConnectPort = IsLich ? m_oGlobals.Config.LichPort : int.Parse(strRow.Substring(9));
                                         }
                                         else if (strRow.IndexOf("KEY=") > -1)
                                         {
                                             m_sConnectKey = strRow.Substring(4);
                                         }
                                     }
+
+
 
                                     if (m_sConnectKey.Length > 0)
                                     {
@@ -2830,7 +2836,7 @@ namespace GenieClient.Genie
                     //    m_oGlobals.Log?.LogText(text + System.Environment.NewLine, Conversions.ToString(m_oGlobals.VariableList["charactername"]), Conversions.ToString(m_oGlobals.VariableList["game"]));
                     //}
 
-               //     m_oGlobals.Log.LogText(text, Conversions.ToString(m_oGlobals.VariableList["charactername"]), Conversions.ToString(m_oGlobals.VariableList["game"]));
+                    //     m_oGlobals.Log.LogText(text, Conversions.ToString(m_oGlobals.VariableList["charactername"]), Conversions.ToString(m_oGlobals.VariableList["game"]));
                 }
             }
 

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -372,9 +372,8 @@ namespace GenieClient.Genie
             }
         }
 
-        public void Connect(string sGenieKey, string sAccountName, string sPassword, string sCharacter, string sGame, bool isLich = false)
+        public void Connect(string sGenieKey, string sAccountName, string sPassword, string sCharacter, string sGame)
         {
-            this.IsLich = isLich;
             m_sAccountName = sAccountName;
             m_sAccountPassword = sPassword;
             m_sAccountCharacter = sCharacter;

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -5125,6 +5125,7 @@ namespace GenieClient
 
         private void ReconnectToGame(bool isLich = false)
         {
+            m_oGame.IsLich = isLich;
             try
             {
                 if (m_oGame.AccountName.Length > 0)
@@ -5135,7 +5136,7 @@ namespace GenieClient
                     string argsPassword = m_oGame.AccountPassword;
                     string argsCharacter = m_oGame.AccountCharacter;
                     string argsGame = m_oGame.AccountGame;
-                    m_oGame.Connect(m_sGenieKey, argsAccountName, argsPassword, argsCharacter, argsGame, isLich);
+                    m_oGame.Connect(m_sGenieKey, argsAccountName, argsPassword, argsCharacter, argsGame);
                 }
             }
             /* TODO ERROR: Skipped IfDirectiveTrivia */
@@ -5148,11 +5149,12 @@ namespace GenieClient
 
         private void ConnectToGame(string sAccountName, string sPassword, string sCharacter, string sGame, bool isLich = false)
         {
+            m_oGame.IsLich = isLich;
             try
             {
                 if (sPassword.Length > 0)
                 {
-                    m_oGame.Connect(m_sGenieKey, sAccountName, sPassword, sCharacter, sGame, isLich);
+                    m_oGame.Connect(m_sGenieKey, sAccountName, sPassword, sCharacter, sGame);
                 }
                 else
                 {
@@ -6904,7 +6906,7 @@ namespace GenieClient
                 {
                     if (sAccount.Length > 0 & sPassword.Length > 0)
                     {
-                        ConnectToGame(sAccount, sPassword, sCharacter, sGame);
+                        ConnectToGame(sAccount, sPassword, sCharacter, sGame, m_oGame.IsLich);
                     }
                     else
                     {

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -5123,7 +5123,7 @@ namespace GenieClient
             }
         }
 
-        private void ReconnectToGame()
+        private void ReconnectToGame(bool isLich = false)
         {
             try
             {
@@ -5135,7 +5135,7 @@ namespace GenieClient
                     string argsPassword = m_oGame.AccountPassword;
                     string argsCharacter = m_oGame.AccountCharacter;
                     string argsGame = m_oGame.AccountGame;
-                    m_oGame.Connect(m_sGenieKey, argsAccountName, argsPassword, argsCharacter, argsGame);
+                    m_oGame.Connect(m_sGenieKey, argsAccountName, argsPassword, argsCharacter, argsGame, isLich);
                 }
             }
             /* TODO ERROR: Skipped IfDirectiveTrivia */
@@ -5146,13 +5146,13 @@ namespace GenieClient
             }
         }
 
-        private void ConnectToGame(string sAccountName, string sPassword, string sCharacter, string sGame)
+        private void ConnectToGame(string sAccountName, string sPassword, string sCharacter, string sGame, bool isLich = false)
         {
             try
             {
                 if (sPassword.Length > 0)
                 {
-                    m_oGame.Connect(m_sGenieKey, sAccountName, sPassword, sCharacter, sGame);
+                    m_oGame.Connect(m_sGenieKey, sAccountName, sPassword, sCharacter, sGame, isLich);
                 }
                 else
                 {

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -44,10 +44,16 @@ namespace GenieClient.Genie
         public string sConfigDirProfile = "Config";
         public bool bShowLinks = false;
         public string sLogDir = "Logs";
-
         // Public sConnectString As String = "/FE:GENIE /VERSION:GENIE3 /XML"
         public string sConnectString = "FE:STORMFRONT /VERSION:1.0.1.26 /P:WIN_XP /XML";
         public int[] iPickerColors = new int[17];
+        public string RubyPath { get; set; } = @"C:\ruby4lich\bin\ruby.exe";
+        public string CmdPath { get; set; } = @"C:\Windows\System32\cmd.exe";
+        public string LichPath { get; set; } = @"C:\ruby4lich\lich.rbw";
+        public string LichArguments { get; set; } = @"--genie --dragonrealms";
+        public string LichServer { get; set; } = "localhost";
+        public int LichPort { get; set; } = 11024;
+        public int LichStartPause { get; set; } = 5;
 
         public string ScriptDir
         {
@@ -285,6 +291,13 @@ namespace GenieClient.Genie
                 oStreamWriter.WriteLine("#config {usertimeout} {" + iUserActivityTimeout + "}");
                 oStreamWriter.WriteLine("#config {usertimeoutcommand} {" + sUserActivityCommand + "}");
                 oStreamWriter.WriteLine("#config {showlinks} {" + bShowLinks + "}");
+                oStreamWriter.WriteLine($"#config {{rubypath}} {{{RubyPath}}}");
+                oStreamWriter.WriteLine($"#config {{cmdpath}} {{{CmdPath}}}");
+                oStreamWriter.WriteLine($"#config {{lichpath}} {{{LichPath}}}");
+                oStreamWriter.WriteLine($"#config {{licharguments}} {{{LichArguments}}}");
+                oStreamWriter.WriteLine($"#config {{lichserver}} {{{LichServer}}}");
+                oStreamWriter.WriteLine($"#config {{lichport}} {{{LichPort}}}");
+                oStreamWriter.WriteLine($"#config {{lichstartpause}} {{{LichStartPause}}}");
                 oStreamWriter.Close();
                 return true;
             }
@@ -795,7 +808,47 @@ namespace GenieClient.Genie
 
                             break;
                         }
+                    case "cmdpath":
+                        {
+                            if (!string.IsNullOrEmpty(sValue)) CmdPath = @$"{sValue}";
+                            break;
+                        }
 
+                    case "rubypath":
+                        {
+                            if(!string.IsNullOrEmpty(sValue)) RubyPath = @$"{sValue}";
+                            break;
+                        }
+
+                    case "lichpath":
+                        {
+                            if (!string.IsNullOrEmpty(sValue)) LichPath = @$"{sValue}";
+                            break;
+                        }
+
+                    case "licharguments":
+                        {
+                            if (!string.IsNullOrEmpty(sValue)) LichArguments = @$"{sValue}";
+                            break;
+                        }
+
+                    case "lichstartpause":
+                        {
+                            if (!string.IsNullOrEmpty(sValue)) LichStartPause = Convert.ToInt32(sValue);
+                            break;
+                        }
+
+                    case "lichserver":
+                        {
+                            if (!string.IsNullOrEmpty(sValue)) LichServer = @$"{sValue}";
+                            break;
+                        }
+
+                    case "lichport":
+                        {
+                            if (!string.IsNullOrEmpty(sValue)) LichPort = Convert.ToInt32(sValue);
+                            break;
+                        }
                     case "automapper":
                         {
                             var switchExpr12 = sValue.ToLower();

--- a/Utility/Utility.cs
+++ b/Utility/Utility.cs
@@ -16,7 +16,7 @@ namespace GenieClient
             return "[" + Strings.FormatDateTime(DateAndTime.Now, DateFormat.ShortTime) + "]";
         }
 
-        public static bool ExecuteProcess(string sFileName, string sArguments)
+        public static bool ExecuteProcess(string sFileName, string sArguments, bool closeProcess = true)
         {
             var myProcess = new Process();
             var myProcessStartInfo = new ProcessStartInfo(sFileName);
@@ -29,12 +29,13 @@ namespace GenieClient
             myProcess.Start();
             var myStreamReader = myProcess.StandardOutput;
             // Read the standard output of the spawned process.
-            while (myProcess.HasExited == false)
-                // If myStreamReader.Peek() > -1 Then
-                // RTBOutput.AppendText(myStreamReader.ReadToEnd() & vbCrLf)
-                // End If
-                Thread.Sleep(10);
-            myProcess.Close();
+            if (closeProcess)
+            {
+                while (myProcess.HasExited == false)
+                    Thread.Sleep(10);
+                myProcess.Close();
+            }
+
             return default;
         }
 


### PR DESCRIPTION
New commands are #lc or #lichconnect and #ls or #lichsettings.
#lc will function exactly like #connect except it will spin up the lich server and point game traffic at localhost or the configured lichserver variable in settings.

#ls will echo out what the current effective settings are.

Added a minor correction to stop IsLich from being overwritten after loading profiles.
