### PR TITLE
Fixing the implicit new on config in global.cs. fixes #20

### DIFF
--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -14,7 +14,7 @@ namespace GenieClient.Genie
 {
     public class Globals
     {
-        private Config _Config = new();
+        private Config _Config = new Config();
        
 
         public Config Config


### PR DESCRIPTION
Changed _config = new() to _config = new config(). This was breaking on some .net framework builds. Fixes #20