### PR TITLE
Highlight, Alias, Trigger, Class and Name bug fix

### DIFF
--- a/Lists/Aliases.cs
+++ b/Lists/Aliases.cs
@@ -26,7 +26,7 @@ namespace GenieClient.Genie
         {
             if (base.ContainsKey(sKey) == true)
             {
-                Remove(sKey);
+                base.Remove(sKey);
                 return 1;
             }
             else

--- a/Lists/Classes.cs
+++ b/Lists/Classes.cs
@@ -124,7 +124,7 @@ namespace GenieClient.Genie
         {
             if (base.ContainsKey(sKey) == true)
             {
-                Remove(sKey);
+                base.Remove(sKey);
                 return 1;
             }
             else

--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -1157,7 +1157,7 @@ namespace GenieClient.Genie
 
                 if (base.ContainsKey(sTrigger) == true)
                 {
-                    Remove(sTrigger);
+                    base.Remove(sTrigger);
                 }
             }
 

--- a/Lists/Highlights.cs
+++ b/Lists/Highlights.cs
@@ -130,7 +130,7 @@ namespace GenieClient.Genie
         {
             if (base.ContainsKey(sKey) == true)
             {
-                Remove(sKey);
+                base.Remove(sKey);
                 return 1;
             }
             else

--- a/Lists/Names.cs
+++ b/Lists/Names.cs
@@ -79,7 +79,7 @@ namespace GenieClient.Genie
         {
             if (base.ContainsKey(sKey) == true)
             {
-                Remove(sKey);
+                base.Remove(sKey);
                 return 1;
             }
             else


### PR DESCRIPTION
When trying to remove configurations items for update or actual removal the call is unintentionally making a recursive call on it's self rather than the base class.  This will correct the issue but this logic could be improved an made more DRY. fixes #27 